### PR TITLE
Remover exposición global del Logger

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -104,4 +104,3 @@ class LoggerService {
 }
 
 export const Logger = new LoggerService();
-window.Logger = Logger; // Acceso global para debug rápido

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,4 +1,5 @@
 // --- UI Utilities ---
+import { Logger } from './logger.js';
 
 export const DOM = {
     toastContainer: document.getElementById('toast-container'),
@@ -78,7 +79,7 @@ export function toggleLogsPanel() {
         return;
     }
 
-    const logs = window.Logger?.getLogs() || [];
+    const logs = Logger?.getLogs() || [];
 
     logsPanel = document.createElement('div');
     logsPanel.id = 'debug-logs-panel';
@@ -101,10 +102,10 @@ export function toggleLogsPanel() {
     // Listeners
     document.getElementById('btn-close-logs').onclick = toggleLogsPanel;
     document.getElementById('btn-clear-logs').onclick = () => {
-        window.Logger?.clear();
+        Logger?.clear();
     };
     document.getElementById('btn-copy-logs').onclick = () => {
-        const text = window.Logger?.exportLogs();
+        const text = Logger?.exportLogs();
         navigator.clipboard.writeText(text);
         mostrarMensaje('Logs copiados al portapapeles', 'success');
     };
@@ -115,7 +116,7 @@ export function toggleLogsPanel() {
 
     // Escuchar nuevos logs mientras está abierto
     const onNewLog = (e) => {
-        container.innerHTML = renderLogsContent(window.Logger.getLogs());
+        container.innerHTML = renderLogsContent(Logger.getLogs());
     };
     document.addEventListener('logger:new-entry', onNewLog);
     document.addEventListener('logger:cleared', onNewLog);


### PR DESCRIPTION
🎯 **Qué:** Se eliminó la exposición global del servicio `Logger` a través de `window.Logger`.
⚠️ **Riesgo:** Exponer el logger globalmente permite que cualquier script en la página (incluyendo scripts maliciosos vía XSS) acceda a los logs, los limpie o inyecte logs falsos, comprometiendo información sensible.
🛡️ **Solución:** Se eliminó la línea `window.Logger = Logger;` en `src/utils/logger.js`. Se actualizó `src/utils/ui.js` para importar `Logger` explícitamente, manteniendo la funcionalidad de depuración de forma segura.

---
*PR created automatically by Jules for task [14916628047164061065](https://jules.google.com/task/14916628047164061065) started by @ThianR*