### PR TITLE
🧹 Eliminar función formatDate sin uso

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,11 +38,6 @@ export async function comprimirImagen(archivo) {
     });
 }
 
-export function formatDate(isoString) {
-    if (!isoString) return '';
-    return new Date(isoString).toLocaleDateString();
-}
-
 export function truncateText(text, length = 100) {
     if (!text) return '';
     return text.length > length ? text.substring(0, length) + '...' : text;


### PR DESCRIPTION
🎯 **Qué:** Se eliminó la función `formatDate` del archivo `src/utils/helpers.js`.
💡 **Por qué:** La función fue identificada como código muerto (sin uso), lo que mejora la mantenibilidad al reducir el tamaño y la confusión en el código base.
✅ **Verificación:** Se verificó mediante `grep` que la función no se utiliza en ninguna parte del código. Se comprobó que `npm run build` se ejecuta correctamente tras la eliminación.
✨ **Resultado:** Código base más limpio sin cambios funcionales.

---
*PR created automatically by Jules for task [15642001953670535589](https://jules.google.com/task/15642001953670535589) started by @ThianR*