### PR TITLE
refactor/eliminar-export-changescreen

### DIFF
--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -16,23 +16,8 @@ export const UIModule = {
     },
     changeView: cambiarVista,
     changeTab: cambiarPestana,
-    changeScreen: cambiarPantalla,
     getCurrentView: () => currentView
 };
-
-function cambiarPantalla(pantallaId) {
-    const screens = document.querySelectorAll('.screen');
-    screens.forEach(s => {
-        s.classList.remove('active'); // Legacy
-        s.classList.remove('screen--active');
-    });
-
-    const targetScreen = document.getElementById(pantallaId);
-    if (targetScreen) {
-        targetScreen.classList.add('screen--active');
-        document.dispatchEvent(new CustomEvent('ui:screen-changed', { detail: { screen: pantallaId } }));
-    }
-}
 
 function cambiarVista(viewName) {
     const views = document.querySelectorAll('.view');


### PR DESCRIPTION
Este PR elimina el método `changeScreen` y su función correspondiente `cambiarPantalla` de `src/modules/ui.js`. Este método fue identificado como código muerto ya que se exportaba pero nunca se usaba internamente ni por otros módulos (excepto por la exportación misma). La aplicación utiliza `cambiarPantalla` desde `src/utils/ui.js` en su lugar.

**Cambios:**
- Se eliminó `changeScreen: cambiarPantalla` de la exportación `UIModule` en `src/modules/ui.js`.
- Se eliminó `function cambiarPantalla(pantallaId) { ... }` de `src/modules/ui.js`.

**Verificación:**
- Se ejecutó `grep` para confirmar que `changeScreen` no se usa en otro lugar.
- Se ejecutó `npm run build` para asegurar que no haya errores de compilación.
- Se verificó que el frontend carga y navega correctamente usando Playwright.

---
*PR created automatically by Jules for task [7905527876170461115](https://jules.google.com/task/7905527876170461115) started by @ThianR*