### PR TITLE
⚡ Optimización de consultas de conteo con índices

### DIFF
--- a/benchmarks/00_count_queries_benchmark.sql
+++ b/benchmarks/00_count_queries_benchmark.sql
@@ -1,0 +1,88 @@
+-- benchmarks/00_count_queries_benchmark.sql
+-- Benchmark para la Optimización de Consultas de Conteo
+-- Ejecuta este script en un cliente PostgreSQL (e.g., psql, pgAdmin) conectado a la base de datos.
+-- Se ejecuta dentro de una transacción y se deshacen los cambios al final (ROLLBACK), sin dejar datos residuales.
+
+BEGIN;
+
+DO $$
+DECLARE
+    target_uid UUID;
+    follower_uid UUID;
+    muni_id UUID;
+    cat_id UUID;
+    i INT;
+    start_ts TIMESTAMP;
+    end_ts TIMESTAMP;
+BEGIN
+    RAISE NOTICE 'Preparando Entorno de Benchmark...';
+
+    -- Asegurar que existe una municipalidad y categoría
+    INSERT INTO municipalidades (nombre, centro) VALUES ('Ciudad Prueba', ST_SetSRID(ST_MakePoint(0,0), 4326))
+    ON CONFLICT (nombre) DO UPDATE SET nombre = EXCLUDED.nombre RETURNING id INTO muni_id;
+
+    INSERT INTO categorias (nombre, descripcion, icono) VALUES ('Categoría Prueba', 'Prueba', 'box')
+    ON CONFLICT (nombre) DO UPDATE SET nombre = EXCLUDED.nombre RETURNING id INTO cat_id;
+
+    -- Crear un usuario objetivo para las consultas
+    INSERT INTO auth.users (id, email, raw_user_meta_data)
+    VALUES (gen_random_uuid(), 'target@prueba.com', '{"full_name": "Usuario Objetivo"}')
+    RETURNING id INTO target_uid;
+
+    -- Generar 10,000 reportes para este usuario
+    INSERT INTO reportes (usuario_id, municipalidad_id, categoria_id, descripcion, ubicacion)
+    SELECT target_uid, muni_id, cat_id, 'Reporte ' || g, ST_SetSRID(ST_MakePoint(0,0), 4326)
+    FROM generate_series(1, 10000) g;
+
+    -- Generar 10,000 comentarios para este usuario
+    INSERT INTO comentarios (reporte_id, usuario_id, contenido)
+    SELECT id, target_uid, 'Comentario'
+    FROM reportes WHERE usuario_id = target_uid;
+
+    -- Generar 10,000 interacciones (votos) para este usuario
+    -- Asumiendo que los reportes existen. Interactuamos con nuestros propios reportes por simplicidad.
+    INSERT INTO interacciones (usuario_id, reporte_id, tipo)
+    SELECT target_uid, id, 'voto_positivo'
+    FROM reportes WHERE usuario_id = target_uid;
+
+    -- Generar 100 seguidores (usuarios que siguen al usuario objetivo)
+    FOR i IN 1..100 LOOP
+        INSERT INTO auth.users (id, email) VALUES (gen_random_uuid(), 'seguidor_' || i || '@prueba.com')
+        RETURNING id INTO follower_uid;
+
+        INSERT INTO seguidores (seguidor_id, siguiendo_id) VALUES (follower_uid, target_uid);
+    END LOOP;
+
+    RAISE NOTICE 'Generación de Datos Completa. Ejecutando Benchmark...';
+
+    -- Medir tiempo de consulta ANTES de los índices
+    start_ts := clock_timestamp();
+    -- Ejecutar 5 veces para promediar
+    FOR i IN 1..5 LOOP
+        PERFORM * FROM obtener_datos_gamificacion(target_uid);
+    END LOOP;
+    end_ts := clock_timestamp();
+
+    RAISE NOTICE 'Duración (Sin Índices) para 5 llamadas: %', end_ts - start_ts;
+
+    -- Crear Índices (simulando la migración)
+    RAISE NOTICE 'Creando Índices...';
+    CREATE INDEX IF NOT EXISTS idx_bench_reportes_uid ON reportes(usuario_id);
+    CREATE INDEX IF NOT EXISTS idx_bench_comentarios_uid ON comentarios(usuario_id);
+    -- Indexamos explícitamente interacciones(usuario_id) aunque la restricción UNIQUE lo cubra usualmente
+    CREATE INDEX IF NOT EXISTS idx_bench_interacciones_uid ON interacciones(usuario_id);
+    CREATE INDEX IF NOT EXISTS idx_bench_seguidores_sid ON seguidores(siguiendo_id);
+
+    -- Medir tiempo de consulta DESPUÉS de los índices
+    start_ts := clock_timestamp();
+    FOR i IN 1..5 LOOP
+        PERFORM * FROM obtener_datos_gamificacion(target_uid);
+    END LOOP;
+    end_ts := clock_timestamp();
+
+    RAISE NOTICE 'Duración (Con Índices) para 5 llamadas: %', end_ts - start_ts;
+
+    RAISE NOTICE 'Benchmark Completado. Deshaciendo cambios...';
+END $$;
+
+ROLLBACK;

--- a/sql/10_optimizaciones.sql
+++ b/sql/10_optimizaciones.sql
@@ -1,0 +1,18 @@
+-- 10_optimizaciones.sql
+-- Índices para mejorar el rendimiento de conteos y filtrado por usuario
+
+-- 1. Índice para reportes por usuario (usado en obtener_datos_gamificacion y v_admin_usuarios)
+CREATE INDEX IF NOT EXISTS idx_reportes_usuario_id ON reportes(usuario_id);
+
+-- 2. Índice para comentarios por usuario (usado en obtener_datos_gamificacion y v_admin_usuarios)
+CREATE INDEX IF NOT EXISTS idx_comentarios_usuario_id ON comentarios(usuario_id);
+
+-- 3. Índice para interacciones por usuario (usado en obtener_datos_gamificacion y v_admin_usuarios)
+-- Aunque existe una restricción UNIQUE(usuario_id, reporte_id, tipo) que podría ser usada,
+-- añadimos un índice explícito para garantizar el rendimiento óptimo en búsquedas por usuario_id.
+CREATE INDEX IF NOT EXISTS idx_interacciones_usuario_id ON interacciones(usuario_id);
+
+-- 4. Índice para seguidores por usuario seguido (usado en obtener_datos_gamificacion y v_admin_usuarios)
+-- Nota: El índice único (seguidor_id, siguiendo_id) ya optimiza la búsqueda por seguidor_id,
+-- pero no por siguiendo_id.
+CREATE INDEX IF NOT EXISTS idx_seguidores_siguiendo_id ON seguidores(siguiendo_id);


### PR DESCRIPTION
Este PR aborda el problema de rendimiento donde las consultas `COUNT(*)` en `obtener_datos_gamificacion` realizaban escaneos completos de tabla en `reportes`, `comentarios`, `interacciones` y `seguidores`.

**Cambios:**
- Se añadió `idx_reportes_usuario_id` en `reportes(usuario_id)`.
- Se añadió `idx_comentarios_usuario_id` en `comentarios(usuario_id)`.
- Se añadió `idx_interacciones_usuario_id` en `interacciones(usuario_id)` (Nota: Añadido explícitamente para robustez, aunque `UNIQUE(usuario_id, ...)` existe).
- Se añadió `idx_seguidores_siguiendo_id` en `seguidores(siguiendo_id)` (Crucial ya que era la segunda columna en un índice compuesto).

**Verificación:**
- Se proporciona un script de benchmark `benchmarks/00_count_queries_benchmark.sql` para medir la mejora de rendimiento. Genera datos de prueba (10k reportes, 10k comentarios, 10k interacciones) y mide el tiempo de consulta antes y después de la creación de índices.

---
*PR created automatically by Jules for task [17217695174235317221](https://jules.google.com/task/17217695174235317221) started by @ThianR*