### PR TITLE
refactor/eliminar-funcion-global-reports

### DIFF
--- a/TECHNICAL_REFERENCE.md
+++ b/TECHNICAL_REFERENCE.md
@@ -41,7 +41,7 @@ Lógica central de reportes, comentarios y votos.
 | `renderTimeline(reporte)` | `reporte` (Object) | Genera la línea de tiempo visual (Creación → Asignación → Resolución). | Calcula tiempos transcurridos entre hitos de tiempo. |
 | `cargarEvidenciasCierre(id, e, obs)` | `id, estado, obs` | Muestra fotos de resolución/rechazo y observaciones del funcionario. | Solo se activa si el estado es final. |
 | `interactuar(tipo)` | `tipo` (String) | Gestiona Votos (+/-) y Seguir reporte. Refresca UI inmediatamente. | **Validación:** Requiere Login. Es tipo toggle. |
-| `verPerfilCiudadano(e, uid, name, avatar)` | Varios | Navega a la vista de perfil del ciudadano y carga sus datos. | Redirige a UIModule.changeView('profile') y emite `profile:load-user`. |
+| `verPerfilCiudadano(uid)` | Internal (Event Delegation) | Navega a la vista de perfil del ciudadano y carga sus datos. | Redirige a UIModule.changeView('profile') y emite `profile:load-user`. |
 
 ---
 

--- a/src/modules/reports.js
+++ b/src/modules/reports.js
@@ -161,6 +161,12 @@ function setupListeners() {
 
     // Delegación para tarjetas de reporte (Click al detalle)
     document.addEventListener('click', (e) => {
+        const profileBtn = e.target.closest('.js-view-profile');
+        if (profileBtn && profileBtn.dataset.userId) {
+            verPerfilCiudadano(profileBtn.dataset.userId);
+            return;
+        }
+
         const card = e.target.closest('.report-card');
         if (card && card.dataset.id) {
             abrirDetalleReporte(card.dataset.id);
@@ -409,7 +415,7 @@ async function renderizarReportes(reportes, containerId) {
                 <p class="report-card__description">${r.descripcion}</p>
                 
                 <div class="report-card__stats">
-                     <div class="report-card__author" title="Ver perfil del ciudadano" onclick="window.verPerfilCiudadano(event, '${r.usuario_id}', '${author.nombre.replace(/'/g, "\\'")}', '${author.avatar_url || ''}')">
+                     <div class="report-card__author js-view-profile" title="Ver perfil del ciudadano" data-user-id="${r.usuario_id}">
                         <i data-lucide="user"></i> Ver Ciudadano
                     </div>
                     
@@ -984,9 +990,7 @@ async function cargarEvidenciasCierre(reporteId, estado, observacion) {
 }
 
 // Función para navegar al perfil de un ciudadano
-async function verPerfilCiudadano(e, userId, userName, userAvatar) {
-    if (e) e.stopPropagation();
-
+async function verPerfilCiudadano(userId) {
     // Navegar a la vista de perfil
     UIModule.changeView('profile');
 
@@ -995,7 +999,3 @@ async function verPerfilCiudadano(e, userId, userName, userAvatar) {
         detail: { userId: userId }
     }));
 }
-
-// Hacerlo global para que funcione el onclick inline
-// O adjuntar listeners de eventos en renderizarReportes.
-window.verPerfilCiudadano = verPerfilCiudadano;


### PR DESCRIPTION
Se refactorizó `src/modules/reports.js` para eliminar la dependencia global `window.verPerfilCiudadano`.
La lógica de clic se trasladó a un listener de eventos delegado dentro de `setupListeners`, utilizando la clase `.js-view-profile` y atributos `data-user-id` en lugar de `onclick` inline.
Se actualizó `TECHNICAL_REFERENCE.md` para reflejar que la función ahora es interna y manejada por eventos.
Se verificó la funcionalidad mediante un script de Playwright que simula la navegación y la interacción con los elementos del reporte.

---
*PR created automatically by Jules for task [9305106952803525552](https://jules.google.com/task/9305106952803525552) started by @ThianR*