### PR TITLE
perf/agregar-indices-reportes

### DIFF
--- a/sql/01_tablas.sql
+++ b/sql/01_tablas.sql
@@ -108,3 +108,16 @@ CREATE TABLE IF NOT EXISTS departamentos (
     creado_en TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE(municipalidad_id, nombre)
 );
+
+-- 10. Índices para Optimización (Performance)
+CREATE INDEX IF NOT EXISTS idx_reportes_usuario_id ON reportes(usuario_id);
+CREATE INDEX IF NOT EXISTS idx_reportes_municipalidad_id ON reportes(municipalidad_id);
+CREATE INDEX IF NOT EXISTS idx_reportes_categoria_id ON reportes(categoria_id);
+CREATE INDEX IF NOT EXISTS idx_reportes_ubicacion ON reportes USING GIST (ubicacion);
+
+-- Índices adicionales para FKs comunes
+CREATE INDEX IF NOT EXISTS idx_evidencias_reporte_id ON evidencias(reporte_id);
+CREATE INDEX IF NOT EXISTS idx_interacciones_reporte_id ON interacciones(reporte_id);
+CREATE INDEX IF NOT EXISTS idx_comentarios_reporte_id ON comentarios(reporte_id);
+CREATE INDEX IF NOT EXISTS idx_comentarios_usuario_id ON comentarios(usuario_id);
+CREATE INDEX IF NOT EXISTS idx_seguidores_siguiendo_id ON seguidores(siguiendo_id);


### PR DESCRIPTION
Implementación de mejoras de rendimiento agregando índices a las claves foráneas en `sql/01_tablas.sql`.

**Por qué:**
- Las consultas que filtran por `municipalidad_id`, `usuario_id` o `categoria_id` son frecuentes en el sistema.
- La vista principal `reportes_final_v1` realiza joins utilizando estas columnas.
- Sin índices, estas operaciones resultan en escaneos secuenciales (Sequential Scans), lo cual degrada el rendimiento conforme crece la base de datos.
- Las consultas espaciales sobre `ubicacion` requieren un índice GIST para ser eficientes.

**Qué se hizo:**
- Se agregaron sentencias `CREATE INDEX IF NOT EXISTS` al final del archivo `sql/01_tablas.sql`.
- Se crearon índices para:
    - `reportes`: `usuario_id`, `municipalidad_id`, `categoria_id`, `ubicacion`.
    - `evidencias`: `reporte_id`.
    - `interacciones`: `reporte_id`.
    - `comentarios`: `reporte_id`, `usuario_id`.
    - `seguidores`: `siguiendo_id`.

**Resultado:**
- Mejora teórica en la complejidad de búsqueda y joins de O(N) a O(log N).
- Verificación de integridad del proyecto realizada con `npm run build`.

---
*PR created automatically by Jules for task [15987118226502228306](https://jules.google.com/task/15987118226502228306) started by @ThianR*