### PR TITLE
fix/supabase-global-exposicion

### DIFF
--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -4,7 +4,4 @@ import { APP_CONFIG } from '../config.js';
 // Asumimos que la librería global 'supabase' ya está cargada vía CDN en index.html
 export const supabaseClient = supabase.createClient(APP_CONFIG.SUPABASE_URL, APP_CONFIG.SUPABASE_KEY);
 
-// Exponer globalmente para depuración y funciones legacy
-window.supabaseClient = supabaseClient;
-
 export default supabaseClient;


### PR DESCRIPTION
Se ha eliminado la exposición global de `supabaseClient` en `src/services/supabase.js` para mejorar la seguridad. Se ha verificado que la aplicación compila correctamente y que ningún otro módulo depende de `window.supabaseClient`.

---
*PR created automatically by Jules for task [7088428905952114369](https://jules.google.com/task/7088428905952114369) started by @ThianR*